### PR TITLE
add notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-| An unofficial fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs) for use by [OpenLineage](https://github.com/OpenLineage/OpenLineage) integrations. |
+| This is an unofficial fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs) for use by [OpenLineage](https://github.com/OpenLineage/OpenLineage) integrations. |
 | --------------------------------------------------------------------------------------------------------- |
 
 # Extensible SQL Lexer and Parser for Rust

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-| :caution: :-- This is a fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs)      |
+| :warning: This is a fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs) :warning: |
 | --------------------------------------------------------------------------------------------------------- |
 | This is not the official parser maintained by the sqlparser-rs community. This fork is used by [OpenLineage](https://github.com/OpenLineage/OpenLineage) project integrations. | 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-| :warning: This is a fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs) :warning: |
+| :warning: This is a fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs)  |
 | --------------------------------------------------------------------------------------------------------- |
-| This is not the official parser maintained by the sqlparser-rs community. This fork is used by [OpenLineage](https://github.com/OpenLineage/OpenLineage) project integrations. | 
+| This is not the official parser maintained by the sqlparser-rs community. Rather, it is a fork of that project used by [OpenLineage](https://github.com/OpenLineage/OpenLineage) integrations. | 
 
 # Extensible SQL Lexer and Parser for Rust
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-| :exclamation: This is a fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs) |
+| :-- :exclamation: Looking for [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs)? |
 | --------------------------------------------------------------------------------------------------------- |
-|This fork of the sqlparser-rs project |
-|is used by the [OpenLineage](https://github.com/OpenLineage/OpenLineage) project. | 
+|This is not the official parser maintained by the sqlparser-rs project. This is a fork used by the [OpenLineage](https://github.com/OpenLineage/OpenLineage) project. | 
 
 # Extensible SQL Lexer and Parser for Rust
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+| :exclamation: Note: this is not [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs) |
+| --------------------------------------------------------------------------------------------------------- |
+This fork of the sqlparser-rs project is not maintained by the sqlparser-rs 
+community. This is a fork of that project used by the [OpenLineage](https://github.com/OpenLineage/OpenLineage) 
+project.
+
 # Extensible SQL Lexer and Parser for Rust
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-| :exclamation: Note: this is not [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs) |
+| :exclamation: This is a fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs). |
 | --------------------------------------------------------------------------------------------------------- |
-This fork of the sqlparser-rs project is not maintained by the sqlparser-rs 
-community. This is a fork of that project used by the [OpenLineage](https://github.com/OpenLineage/OpenLineage) 
-project.
+|This fork of the sqlparser-rs project is used by the [OpenLineage](https://github.com/OpenLineage/OpenLineage) project. | 
 
 # Extensible SQL Lexer and Parser for Rust
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-| :exclamation: This is a fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs)      |
+| :caution: :-- This is a fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs)      |
 | --------------------------------------------------------------------------------------------------------- |
-|This is not the official parser maintained by the sqlparser-rs project. This is a fork used by the [OpenLineage](https://github.com/OpenLineage/OpenLineage) project. | 
+| This is not the official parser maintained by the sqlparser-rs community. This fork is used by [OpenLineage](https://github.com/OpenLineage/OpenLineage) project integrations. | 
 
 # Extensible SQL Lexer and Parser for Rust
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,5 @@
-<style>
-  .forkNotice th {
-    background: grey
-  }
-</style>
-
-<div class='forkNotice'>
 | This is an unofficial fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs) for use by [OpenLineage](https://github.com/OpenLineage/OpenLineage) integrations. |
 | --------------------------------------------------------------------------------------------------------- |
-</div>
 
 # Extensible SQL Lexer and Parser for Rust
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-| :-- :exclamation: Looking for [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs)? |
+| :exclamation: This is a fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs)      |
 | --------------------------------------------------------------------------------------------------------- |
 |This is not the official parser maintained by the sqlparser-rs project. This is a fork used by the [OpenLineage](https://github.com/OpenLineage/OpenLineage) project. | 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
+<style>
+  .forkNotice th {
+    background: grey
+  }
+</style>
+
+<div class='forkNotice'>
 | This is an unofficial fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs) for use by [OpenLineage](https://github.com/OpenLineage/OpenLineage) integrations. |
 | --------------------------------------------------------------------------------------------------------- |
+</div>
 
 # Extensible SQL Lexer and Parser for Rust
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-| :warning: This is a fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs) :warning: |
+| Forked from [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs) |
 | --------------------------------------------------------------------------------------------------------- |
-| This is not the official parser maintained by the sqlparser-rs community. Rather, it is a fork of that project used by [OpenLineage](https://github.com/OpenLineage/OpenLineage) integrations. | 
+| This is an unofficial fork of sqlparser-rs used by [OpenLineage](https://github.com/OpenLineage/OpenLineage) integrations. | 
 
 # Extensible SQL Lexer and Parser for Rust
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-| Forked from [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs) |
+| An unofficial fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs) for use by [OpenLineage](https://github.com/OpenLineage/OpenLineage) integrations. |
 | --------------------------------------------------------------------------------------------------------- |
-| This is an unofficial fork of sqlparser-rs used by [OpenLineage](https://github.com/OpenLineage/OpenLineage) integrations. | 
 
 # Extensible SQL Lexer and Parser for Rust
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-| :exclamation: This is a fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs). |
+| :exclamation: This is a fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs) |
 | --------------------------------------------------------------------------------------------------------- |
-|This fork of the sqlparser-rs project is used by the [OpenLineage](https://github.com/OpenLineage/OpenLineage) project. | 
+|This fork of the sqlparser-rs project |
+|is used by the [OpenLineage](https://github.com/OpenLineage/OpenLineage) project. | 
 
 # Extensible SQL Lexer and Parser for Rust
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-| :warning: This is a fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs)  |
+| :warning: This is a fork of [sqlparser-rs/sqlparser-rs](https://github.com/sqlparser-rs/sqlparser-rs) :warning: |
 | --------------------------------------------------------------------------------------------------------- |
 | This is not the official parser maintained by the sqlparser-rs community. Rather, it is a fork of that project used by [OpenLineage](https://github.com/OpenLineage/OpenLineage) integrations. | 
 


### PR DESCRIPTION
We need a way to help ensure that those who are looking for the official parser don't confuse it with our fork. This adds a notice to the README.